### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ When you do not need to launch `rqt_reconfigure`,
 please set a launch option as below.
 
 ```
-$ roslaunch cis_camera pointcloud.launch reconfigure:=false
+$ roslaunch cis_camera pointcloud.launch reconfigure:=true
 ```
 
 ![RViz PointCloud.launch](doc/images/ros_cis_camera_rviz-pointcloud_20190923.png)


### PR DESCRIPTION
`roslaunch cis_camera pointcloud.launch reconfigure:=true` is correct for launching dynamic_reconfigure, `false` is not to launch dynamic_reconfigure. 