### PR TITLE
Add edge extraction for flying pixel

### DIFF
--- a/cfg/CISCamera.cfg
+++ b/cfg/CISCamera.cfg
@@ -48,6 +48,10 @@ rgb_hard.add( "brightness_gain", double_t, RECONFIGURE_RUNNING,
 rgb_hard.add( "exposure_time", double_t, RECONFIGURE_RUNNING, 
               "RGB Exposure Time (Shutter Control)", 0.01, 0.00001, 0.01 )
 
+d_filter = gen.add_group( "Depth Image Filter Configurarions" )
+d_filter.add( "depth_filter", bool_t, RECONFIGURE_RUNNING, "Depth Image Filter On/Off", True )
+d_filter.add( "dilate_iterations", int_t, RECONFIGURE_RUNNING, "Dilate Iterations", 2, 0, 10 )
+
 dir_soft = gen.add_group( "Depth IR Camera Distortion Correction on Driver Software" )
 dir_soft.add( "ir_dist_reconfig", bool_t, RECONFIGURE_RUNNING, "IR/Depth Camera Distortion Correction Reconfigure", False )
 dir_soft.add( "ir_fx", double_t, RECONFIGURE_RUNNING, "IR/Depth Camera Fx", 390.000, 100.0, 500.0 )

--- a/cfg/CISCamera.cfg
+++ b/cfg/CISCamera.cfg
@@ -51,6 +51,11 @@ rgb_hard.add( "exposure_time", double_t, RECONFIGURE_RUNNING,
 d_filter = gen.add_group( "Depth Image Filter Configurarions" )
 d_filter.add( "depth_filter", bool_t, RECONFIGURE_RUNNING, "Depth Image Filter On/Off", True )
 d_filter.add( "dilate_iterations", int_t, RECONFIGURE_RUNNING, "Dilate Iterations", 1, 0, 10 )
+blur_enum = gen.enum([ gen.const( "Gaussian", int_t, 0, "Gaussian" ),
+                       gen.const( "Median"  , int_t, 1, "Median" ) ],
+                       "An enum of Blur Modes for Pre Edge Extraction" )
+d_filter.add( "blur_mode", int_t, RECONFIGURE_RUNNING, 
+              "Blur Mode for Pre Edge Extraction", 0, 0, 1, edit_method = blur_enum )
 edge_enum = gen.enum([ gen.const( "Sobel"    , int_t, 0, "Sobel" ),
                        gen.const( "Laplacian", int_t, 1, "Laplacian" ) ],
                        "An enum of Edge Extraction Modes" )

--- a/cfg/CISCamera.cfg
+++ b/cfg/CISCamera.cfg
@@ -50,7 +50,12 @@ rgb_hard.add( "exposure_time", double_t, RECONFIGURE_RUNNING,
 
 d_filter = gen.add_group( "Depth Image Filter Configurarions" )
 d_filter.add( "depth_filter", bool_t, RECONFIGURE_RUNNING, "Depth Image Filter On/Off", True )
-d_filter.add( "dilate_iterations", int_t, RECONFIGURE_RUNNING, "Dilate Iterations", 2, 0, 10 )
+d_filter.add( "dilate_iterations", int_t, RECONFIGURE_RUNNING, "Dilate Iterations", 1, 0, 10 )
+edge_enum = gen.enum([ gen.const( "Sobel"    , int_t, 0, "Sobel" ),
+                       gen.const( "Laplacian", int_t, 1, "Laplacian" ) ],
+                       "An enum of Edge Extraction Modes" )
+d_filter.add( "edge_mode", int_t, RECONFIGURE_RUNNING, 
+              "Edge Extraction Mode", 0, 0, 1, edit_method = edge_enum )
 
 dir_soft = gen.add_group( "Depth IR Camera Distortion Correction on Driver Software" )
 dir_soft.add( "ir_dist_reconfig", bool_t, RECONFIGURE_RUNNING, "IR/Depth Camera Distortion Correction Reconfigure", False )

--- a/include/cis_camera/camera_driver.h
+++ b/include/cis_camera/camera_driver.h
@@ -131,6 +131,7 @@ private:
   void ReconfigureCallback( CISCameraConfig &config, uint32_t level );
   
   // Accept a new image frame from the camera
+  void filterDepthImage( sensor_msgs::ImagePtr& msg );
   void ImageCallback( uvc_frame_t *frame );
   static void ImageCallbackAdapter( uvc_frame_t *frame, void *ptr );
   

--- a/launch/pcl_pipeline_example.launch
+++ b/launch/pcl_pipeline_example.launch
@@ -68,6 +68,7 @@
     <remap from="~indices" to="/planar_segmentation/inliers" />
     <rosparam>
       negative: true
+      approximate_sync: true
     </rosparam>
   </node>
   

--- a/launch/pcl_pipeline_example.launch
+++ b/launch/pcl_pipeline_example.launch
@@ -1,0 +1,86 @@
+<launch>
+  
+  <arg name="manager_name" value="pcl_pipeline_nodelet_manager"/>
+  
+  <node pkg="nodelet" type="nodelet" name="$(arg manager_name)"
+        args="manager" output="screen" />
+  
+  <node pkg="nodelet" type="nodelet" name="voxel_grid"
+        args="load pcl/VoxelGrid $(arg manager_name)" >
+    <remap from="~input" to="/camera/depth/points" />
+    <rosparam>
+      filter_field_name: z
+      filter_limit_min: 0.1
+      filter_limit_max: 6.0
+      filter_limit_negative: false
+      leaf_size: 0.01
+    </rosparam>
+  </node>
+
+  <node pkg="nodelet" type="nodelet" name="crop_box"
+        args="load pcl/CropBox $(arg manager_name)" >
+    <remap from="~input"   to="/voxel_grid/output" />
+    <rosparam>
+      min_x: -0.2
+      max_x:  0.2
+      min_y: -0.3
+      max_y:  0.3
+      min_z:  0.15
+      max_z:  1.0
+    </rosparam>
+  </node>
+  
+  <node pkg="nodelet" type="nodelet" name="planar_segmentation"
+        args="load pcl/SACSegmentation $(arg manager_name)" >
+    <remap from="~input"   to="/crop_box/output" />
+    <rosparam>
+      # -[ Mandatory parameters
+      # model_type:
+      # 0:  SACMODEL_PLANE
+      # 1:  SACMODEL_LINE
+      # 2:  SACMODEL_CIRCLE2D
+      # 3:  SACMODEL_CIRCLE3D
+      # 4:  SACMODEL_SPHERE
+      # 5:  SACMODEL_CYLINDER
+      # 6:  SACMODEL_CONE
+      # 7:  SACMODEL_TORUS
+      # 8:  SACMODEL_PARALLEL_LINE
+      # 9:  SACMODEL_PERPENDICULAR_PLANE
+      # 10: SACMODEL_PARALLEL_LINES
+      # 11: SACMODEL_NORMAL_PLANE
+      # 12: SACMODEL_NORMAL_SPHERE
+      # 13: SACMODEL_REGISTRATION
+      # 14: SACMODEL_REGISTRATION_2D
+      # 15: SACMODEL_PARALLEL_PLANE
+      # 16: SACMODEL_NORMAL_PARALLEL_PLANE
+      # 17: SACMODEL_STICK
+      model_type: 0
+      method_type: 0
+      distance_threshold: 0.01
+      max_iterations: 200
+      optimize_coefficients: true
+    </rosparam>
+  </node>
+  
+  <node pkg="nodelet" type="nodelet" name="extract_indices"
+        args="load pcl/ExtractIndices $(arg manager_name)" >
+    <remap from="~input"   to="/crop_box/output" />
+    <remap from="~indices" to="/planar_segmentation/inliers" />
+    <rosparam>
+      negative: true
+    </rosparam>
+  </node>
+  
+  <node pkg="nodelet" type="nodelet" name="euclidian_cluster"
+        args="load pcl/EuclideanClusterExtraction $(arg manager_name)" >
+    <remap from="~input"   to="/extract_indices/output" />
+    <rosparam>
+      cluster_tolerance: 0.01
+      cluster_min_size: 100
+      cluster_max_size: 10000
+      spatial_locator: 0
+    </rosparam>
+  </node>
+  
+  
+</launch>

--- a/src/camera_driver.cpp
+++ b/src/camera_driver.cpp
@@ -327,8 +327,14 @@ void CameraDriver::filterDepthImage( sensor_msgs::ImagePtr& msg )
   
   // Median Blur Filter
   int median_blur_size = 3;
-  cv::Mat mdb_img;
-  cv::medianBlur( src_img, mdb_img, median_blur_size );
+  cv::Mat blr_img;
+  
+  int blur_mode = 0;
+  priv_nh_.getParam( "blur_mode", blur_mode );
+  if ( blur_mode == 1 )
+    cv::medianBlur( src_img, blr_img, median_blur_size );
+  else
+    cv::GaussianBlur( src_img, blr_img, cv::Size(3, 3), 0, 0, cv::BORDER_DEFAULT);
   
   // Edge Extraction
   int edge_threshold    = 128;
@@ -340,13 +346,13 @@ void CameraDriver::filterDepthImage( sensor_msgs::ImagePtr& msg )
   priv_nh_.getParam( "edge_mode", edge_mode );
   if ( edge_mode == 1 )
   {
-    cv::Laplacian( mdb_img, edg_img, CV_32F, 3 );
+    cv::Laplacian( blr_img, edg_img, CV_32F, 3 );
   }
   else
   {
     cv::Mat sbx_img, sby_img;
-    cv::Sobel( mdb_img, sbx_img, CV_32F, 1, 0 );
-    cv::Sobel( mdb_img, sby_img, CV_32F, 0, 1 );
+    cv::Sobel( blr_img, sbx_img, CV_32F, 1, 0 );
+    cv::Sobel( blr_img, sby_img, CV_32F, 0, 1 );
     edg_img = ( cv::abs( sbx_img ) + cv::abs( sby_img ) ) / 2.0;
   }
   

--- a/src/camera_driver.cpp
+++ b/src/camera_driver.cpp
@@ -361,14 +361,13 @@ void CameraDriver::filterDepthImage( sensor_msgs::ImagePtr& msg )
   cv::dilate( edg_img, edg_img, cv::Mat(), cv::Point(-1,-1), dilate_iterations );
   
   // Set Depth Data as NaN on the Edges
-  float nan = std::numeric_limits<float>::quiet_NaN();
   for ( int i = 0; i < edg_img.rows; i++ )
   {
     for ( int j = 0; j < edg_img.cols; j++ )
     {
       if ( 0 < edg_img.at<uint8_t>(i,j) )
       {
-        src_img.at<uint16_t>(i,j) = nan;
+        src_img.at<uint16_t>(i,j) = 0;
       }
     }
   }


### PR DESCRIPTION
- add flying pixel filter for depth_image (2D) with OpenCV.
  - Blur Filter + Edge Extraction + Dilate + Set Edge Area as 0
- add pcl_pipeline_example.launch with NodeletLazy
  - Nodelets subscribe topics only when sbscribed.
  - set ExtraceIndices`approximate_sync` as `true`