### PR TITLE
ros_buildfarm on melodic requires python >= 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: true
 dist: trusty
 language: python
 python:
-  - "3.4"
+  - "3.6"
 env:
   global:
     - JOB_PATH=/tmp/devel_job

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cis_camera [![Build Status](https://travis-ci.com/tork-a/cis_camera.svg?branch=master)](https://travis-ci.org/tork-a/cis_camera)
+# cis_camera [![Build Status](https://travis-ci.com/tork-a/cis_camera.svg?branch=master)](https://travis-ci.com/tork-a/cis_camera)
 
 This package contains ROS driver nodes for CIS Corporation ToF Camera Sensor DCC-RGBD1 with USB 3.0 interface.
 


### PR DESCRIPTION
https://travis-ci.com/tork-a/cis_camera/builds/144050472